### PR TITLE
fixed postscript in capture function by removing duplucate line

### DIFF
--- a/postscript.py
+++ b/postscript.py
@@ -633,7 +633,6 @@ class postscript(printer):
                  '  %-------------------------------------------------------------------\n'\
                  '  setoldtime                                                          \n'\
                  '  } ifelse} ifelse} stopped} bind def                                 \n'\
-                 '} ifelse} ifelse} bind def                                            \n'\
                  '<< /BeginPage {capturehook} bind >> setpagedevice                     \n'\
                  '(Future print jobs will be captured in memory!)}                      \n'\
                  '{(Cannot capture - unlock me first)} ifelse print'


### PR DESCRIPTION
The postscript specified in postscript.py do_capture() was not valid and lead to the tested printers rejecting that command.