### PR TITLE
Fix exception on get with python 3

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -392,7 +392,7 @@ class conn(object):
   # receive data
   def recv(self, bytes):
     # receive data from device
-    if self._file: data = os.read(self._file, bytes)
+    if self._file: data = os.read(self._file, bytes).decode()
     # receive data from socket
     else: data = self._sock.recv(bytes).decode()
     # output recv data when in debug mode

--- a/printer.py
+++ b/printer.py
@@ -408,7 +408,7 @@ class printer(cmd.Cmd, object):
       if lsize != rsize and len(conv().nstrip(data)) == rsize:
         lsize, data = rsize, conv().nstrip(data)
       # write to local file
-      file().write(lpath, data)
+      file().write(lpath, data.encode())
       if lsize == rsize:
         print((str(lsize) + " bytes received."))
       else:


### PR DESCRIPTION
This fixes a "Program Error (a bytes-like object is required, not 'str')" error when trying to "get" from my InfoPrint 1552 (aka Lexmark T644).

However, there are some files I've tried to get that still don't work, now I get a "Command execution failed ('utf-8' codec can't decode byte 0xfb in position 40: invalid start byte)" for some files. Not sure how to fix that one aside from moving everything to bytes, which breaks regexes.
﻿

This probably further fixes #47 
